### PR TITLE
version 0.5.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,7 +26,7 @@ build_type = release
 lib_deps =
 	og3@^0.3.19
 	og3x-lora@^0.4.0
-	og3x-satellite@^0.1.2
+	og3x-satellite@^0.1.3
 	og3x-oled@^0.3.1
 	og3x-shtc3@^0.3.0
 	adafruit/Adafruit BusIO

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@
 
 #include "og3/variable.h"
 
-#define VERSION "0.4.3"
+#define VERSION "0.5.0"
 
 namespace og3 {
 
@@ -181,9 +181,10 @@ void parse_device_packet(uint16_t seq_id, const uint8_t* msg, std::size_t msg_si
       s_app.log().logf(" sw: %u.%u.%u", ver.major, ver.minor, ver.patch);
     }
     auto iter = s_id_to_device.emplace(
-        packet.device_id, new base_station::Device(packet.device_id, device.name,
-                                                   device.manufacturer, &s_app.module_system(),
-                                                   &s_app.ha_discovery(), seq_id, s_device_cvg));
+        packet.device_id,
+        new base_station::Device(packet.device_id, device.name, device.manufacturer,
+                                 device.device_type, &s_app.module_system(), &s_app.ha_discovery(),
+                                 seq_id, s_device_cvg));
     pdevice = iter.first->second.get();
     pdevice->set_disabled(s_device_disable_default.value());
   }


### PR DESCRIPTION
- Use updated og3x-satellite library for protocol update
- Use device name directly from satellite protobuf as HA discovery device name
- Use new device_type as model in HA device