### PR TITLE
version 0.1.5: set readings failed before parsing LoRa packet

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,7 +26,7 @@ build_type = release
 lib_deps =
 	og3@^0.3.19
 	og3x-lora@^0.4.0
-	og3x-satellite@^0.1.4
+	og3x-satellite@^0.1.5
 	og3x-oled@^0.3.1
 	og3x-shtc3@^0.3.0
 	adafruit/Adafruit BusIO
@@ -43,8 +43,6 @@ lib_deps =
 
 build_flags =
 	'-Wall'
-	'-I/home/chris/Projects2/LoRa133/.pio/libdeps/node32s/Nanopb/'
-	'-I/home/chris/Projects2/LoRa133/.pio/build/node32s/nanopb/generated-src'
 ;	'-D LOG_DEBUG'
 	'-D LOG_UDP'
 	'-D LOG_UDP_ADDRESS=${secrets.udpLogTarget}'

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@
 
 #include "og3/variable.h"
 
-#define VERSION "0.5.1"
+#define VERSION "0.5.2"
 
 namespace og3 {
 
@@ -190,6 +190,10 @@ void parse_device_packet(uint16_t seq_id, const uint8_t* msg, std::size_t msg_si
   }
 
   s_pkt_count = s_pkt_count.value() + 1;
+
+  // Set all device sensor readings to "Failed" so we don't re-use values not included in
+  //  this packet.
+  pdevice->setAllSensorReadingsFailed();
 
   // Read the sensor entries.
   for (unsigned idx_sensor = 0; idx_sensor < packet.sensor_count; idx_sensor++) {


### PR DESCRIPTION
This keeps value not in LoRa packets out of MQTT messages.